### PR TITLE
SwiftUI レイアウト一本勝負 002

### DIFF
--- a/LayoutGame.xcodeproj/project.pbxproj
+++ b/LayoutGame.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		28628328288B6C6900B96587 /* Vital.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28628327288B6C6900B96587 /* Vital.swift */; };
+		28628329288B6C7300B96587 /* Vital.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28628327288B6C6900B96587 /* Vital.swift */; };
+		2862832B288B6D7F00B96587 /* Topic002View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2862832A288B6D7F00B96587 /* Topic002View.swift */; };
+		2862832C288B6D8300B96587 /* Topic002View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2862832A288B6D7F00B96587 /* Topic002View.swift */; };
+		2862832E288B6FEC00B96587 /* Topic002DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2862832D288B6FEC00B96587 /* Topic002DetailView.swift */; };
+		2862832F288B6FEC00B96587 /* Topic002DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2862832D288B6FEC00B96587 /* Topic002DetailView.swift */; };
+		28628331288B72B400B96587 /* Topic002CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28628330288B72B400B96587 /* Topic002CardView.swift */; };
+		28628332288B72B400B96587 /* Topic002CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28628330288B72B400B96587 /* Topic002CardView.swift */; };
 		28632C48287F001600F07F80 /* LayoutGameApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28632C47287F001600F07F80 /* LayoutGameApp.swift */; };
 		28632C4A287F001600F07F80 /* Try001View.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28632C49287F001600F07F80 /* Try001View.swift */; };
 		28632C4C287F001700F07F80 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 28632C4B287F001700F07F80 /* Assets.xcassets */; };
@@ -85,6 +93,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		28628327288B6C6900B96587 /* Vital.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vital.swift; sourceTree = "<group>"; };
+		2862832A288B6D7F00B96587 /* Topic002View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic002View.swift; sourceTree = "<group>"; };
+		2862832D288B6FEC00B96587 /* Topic002DetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic002DetailView.swift; sourceTree = "<group>"; };
+		28628330288B72B400B96587 /* Topic002CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Topic002CardView.swift; sourceTree = "<group>"; };
 		28632C44287F001600F07F80 /* LayoutGame.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = LayoutGame.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		28632C47287F001600F07F80 /* LayoutGameApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutGameApp.swift; sourceTree = "<group>"; };
 		28632C49287F001600F07F80 /* Try001View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Try001View.swift; sourceTree = "<group>"; };
@@ -140,6 +152,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		28628325288B6C3000B96587 /* Topic002 */ = {
+			isa = PBXGroup;
+			children = (
+				28628330288B72B400B96587 /* Topic002CardView.swift */,
+				2862832D288B6FEC00B96587 /* Topic002DetailView.swift */,
+				2862832A288B6D7F00B96587 /* Topic002View.swift */,
+				28628326288B6C5000B96587 /* Model */,
+			);
+			path = Topic002;
+			sourceTree = "<group>";
+		};
+		28628326288B6C5000B96587 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				28628327288B6C6900B96587 /* Vital.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
 		28632C3B287F001600F07F80 = {
 			isa = PBXGroup;
 			children = (
@@ -167,11 +198,12 @@
 		28632C46287F001600F07F80 /* LayoutGame */ = {
 			isa = PBXGroup;
 			children = (
-				28632C47287F001600F07F80 /* LayoutGameApp.swift */,
 				28632C72287F083200F07F80 /* HomeView.swift */,
+				28632C47287F001600F07F80 /* LayoutGameApp.swift */,
 				28632C49287F001600F07F80 /* Try001View.swift */,
 				28632C4B287F001700F07F80 /* Assets.xcassets */,
 				28632C4D287F001700F07F80 /* Preview Content */,
+				28628325288B6C3000B96587 /* Topic002 */,
 			);
 			path = LayoutGame;
 			sourceTree = "<group>";
@@ -446,7 +478,11 @@
 			files = (
 				28632C73287F083200F07F80 /* HomeView.swift in Sources */,
 				28632C4A287F001600F07F80 /* Try001View.swift in Sources */,
+				2862832E288B6FEC00B96587 /* Topic002DetailView.swift in Sources */,
+				28628328288B6C6900B96587 /* Vital.swift in Sources */,
+				2862832B288B6D7F00B96587 /* Topic002View.swift in Sources */,
 				28632C48287F001600F07F80 /* LayoutGameApp.swift in Sources */,
+				28628331288B72B400B96587 /* Topic002CardView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -472,11 +508,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				28632C88287F145700F07F80 /* NotificationController.swift in Sources */,
+				2862832C288B6D8300B96587 /* Topic002View.swift in Sources */,
 				28632C8C287F145700F07F80 /* ComplicationController.swift in Sources */,
+				28628332288B72B400B96587 /* Topic002CardView.swift in Sources */,
 				28632CBB287F14AD00F07F80 /* LayoutGameApp.swift in Sources */,
 				28632CBC287F14B200F07F80 /* Try001View.swift in Sources */,
 				28632CBD287F14B500F07F80 /* HomeView.swift in Sources */,
+				28628329288B6C7300B96587 /* Vital.swift in Sources */,
 				28632C8A287F145700F07F80 /* NotificationView.swift in Sources */,
+				2862832F288B6FEC00B96587 /* Topic002DetailView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LayoutGame/HomeView.swift
+++ b/LayoutGame/HomeView.swift
@@ -13,6 +13,9 @@ struct HomeView: View {
             NavigationLink(destination: Try001View()) {
                 Text("001")
             }
+            NavigationLink(destination: Topic002View()) {
+                Text("002")
+            }
         }
         .navigationTitle("レイアウト一本勝負")
     }

--- a/LayoutGame/Topic002/Model/Vital.swift
+++ b/LayoutGame/Topic002/Model/Vital.swift
@@ -27,6 +27,39 @@ extension Vital {
         case number(value: Double, style: NumberFormatter.Style, customUnit: String? = nil)
         case dateComponents(_ dateComponents: DateComponents)
         case measurement(value: Double, unit: Dimension, formattedUnit: Dimension? = nil)
+
+        // MARK: Private Computed Properties
+
+        private var dateComponentsFormatter: DateComponentsFormatter {
+            let formatter = DateComponentsFormatter()
+            formatter.unitsStyle = .full
+            formatter.allowedUnits = [.day, .hour, .minute]
+            return formatter
+        }
+
+        // MARK: Internal Computed Properties
+        
+        /// 値のデータを整理し、単位付きの文字列に変換した文字列。
+        var text: String {
+            switch self {
+            case let .number(value, style, customUnit):
+                let formatter = numberFormatter(style: style)
+                return "\(formatter.string(from: value as NSNumber) ?? "")\(customUnit ?? "")"
+            case let .dateComponents(dateComponents):
+                return dateComponentsFormatter.string(from: dateComponents) ?? ""
+            case let .measurement(value, unit, formattedUnit):
+                return "\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)"
+            }
+        }
+
+        // MARK: Private Functions
+
+        private func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {
+            let formatter = NumberFormatter()
+            formatter.numberStyle = style
+            formatter.locale = .current
+            return formatter
+        }
     }
 }
 

--- a/LayoutGame/Topic002/Model/Vital.swift
+++ b/LayoutGame/Topic002/Model/Vital.swift
@@ -1,0 +1,42 @@
+//
+//  Vital.swift
+//  LayoutGame
+//
+//  Created by MiharuNaruse on 2022/07/23.
+//
+
+import SwiftUI
+
+// MARK: - Vital
+
+struct Vital: Identifiable {
+    let id = UUID()
+    let title: LocalizedStringKey
+    let value: Value
+    let date: Date
+    let iconSystemName: String
+    let color: Color
+}
+
+// MARK: - Extension Vital
+
+extension Vital {
+    // MARK: Enums
+
+    enum Value {
+        case number(value: Double, style: NumberFormatter.Style, customUnit: String? = nil)
+        case dateComponents(_ dateComponents: DateComponents)
+        case measurement(value: Double, unit: Dimension, formattedUnit: Dimension? = nil)
+    }
+}
+
+// MARK: - Extension Sample Data
+
+extension Vital {
+    static let sampleData: [Vital] = [
+        .init(title: "取り込まれた酸素のレベル", value: .number(value: 0.99, style: .percent), date: Date(timeIntervalSinceNow: -300), iconSystemName: "o.circle.fill", color: .blue),
+        .init(title: "心拍数", value: .number(value: 61, style: .decimal, customUnit: "拍/分"), date: Date(timeIntervalSinceNow: -5400), iconSystemName: "heart.fill", color: .red),
+        .init(title: "睡眠", value: .dateComponents(.init(minute: 451)), date: Date(timeIntervalSinceNow: -87000), iconSystemName: "bed.double.fill", color: .green),
+        .init(title: "体温", value: .measurement(value: 36.4, unit: UnitTemperature.celsius), date: Date(timeIntervalSinceNow: -172800), iconSystemName: "thermometer", color: .red),
+    ]
+}

--- a/LayoutGame/Topic002/Model/Vital.swift
+++ b/LayoutGame/Topic002/Model/Vital.swift
@@ -38,7 +38,7 @@ extension Vital {
         }
 
         // MARK: Internal Computed Properties
-        
+
         /// 値のデータを整理し、単位付きの文字列に変換した文字列。
         var text: String {
             switch self {
@@ -50,6 +50,15 @@ extension Vital {
             case let .measurement(value, unit, formattedUnit):
                 return "\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)"
             }
+        }
+
+        // MARK: Internal Functions
+
+        /// 文字を目立つ装飾にすべきか否か。
+        /// - Parameter character: 一文字
+        /// - Returns: `true` : 目立つ装飾にすべき。 `false` : 目立つ装飾にすべきでない。
+        func shouldBeProminentDecoration(_ character: String.Element) -> Bool {
+            character.isNumber || ["."].contains(character)
         }
 
         // MARK: Private Functions

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -13,13 +13,6 @@ struct Topic002CardView: View {
 
     var vital: Vital
 
-    private var dateComponentsFormatter: DateComponentsFormatter {
-        let formatter = DateComponentsFormatter()
-        formatter.unitsStyle = .full
-        formatter.allowedUnits = [.day, .hour, .minute]
-        return formatter
-    }
-
     // MARK: Body
 
     var body: some View {
@@ -34,29 +27,12 @@ struct Topic002CardView: View {
                     .foregroundColor(.secondary)
             }
             Spacer(minLength: 16)
-            switch vital.value {
-            case let .number(value: value, style: style, customUnit: customUnit):
-                let formatter = numberFormatter(style: style)
-                modifiedText("\(formatter.string(from: value as NSNumber) ?? "")\(customUnit ?? "")")
-
-            case let .dateComponents(dateComponents):
-                modifiedText(dateComponentsFormatter.string(from: dateComponents) ?? "")
-
-            case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
-                modifiedText("\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)")
-            }
+            modifiedText(vital.value.text)
         }
         .padding(.vertical, 8)
     }
 
     // MARK: Private Functions
-
-    private func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = style
-        formatter.locale = .current
-        return formatter
-    }
 
     /// 数値か否かによって、テキストを装飾する。
     /// - Parameter text: 装飾対象の文字列

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -13,6 +13,13 @@ struct Topic002CardView: View {
 
     var vital: Vital
 
+    var dateComponentsFormatter: DateComponentsFormatter {
+        let formatter = DateComponentsFormatter()
+        formatter.unitsStyle = .full
+        formatter.allowedUnits = [.day, .hour, .minute]
+        return formatter
+    }
+
     // MARK: Body
 
     var body: some View {
@@ -36,9 +43,9 @@ struct Topic002CardView: View {
                     .font(.title)
 
             case let .dateComponents(dateComponents):
-                // TODO: DateComponents をフォーマットする。
-//                Text(dateComponents, style: .offset)
-                Text("Hello, world!")
+                // TODO: フォントサイズ
+                Text(dateComponentsFormatter.string(from: dateComponents) ?? "")
+                    .font(.title)
 
             case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
                 // TODO: フォントサイズ

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -64,7 +64,7 @@ struct Topic002CardView: View {
     private func modifiedText(_ text: String) -> Text {
         text
             .map {
-                if $0.isNumber {
+                if $0.isNumber || ["."].contains($0) {
                     return Text(String($0))
                         .font(.system(.title, design: .rounded).weight(.medium))
                 } else {

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -30,10 +30,10 @@ struct Topic002CardView: View {
                     .font(.headline)
                 Spacer()
                 Text(RelativeDateTimeFormatter().localizedString(for: vital.date, relativeTo: Date.now))
-                    .font(.subheadline)
+                    .font(.footnote)
                     .foregroundColor(.secondary)
             }
-            Spacer()
+            Spacer(minLength: 16)
             switch vital.value {
             case let .number(value: value, style: style, customUnit: customUnit):
 
@@ -49,11 +49,12 @@ struct Topic002CardView: View {
 
             case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
                 // TODO: フォントサイズ
+                // TODO: `formattedUnit` 使うこと
                 Text("\(String(format: "%.1f", value))\(unit.symbol)")
                     .font(.title)
             }
         }
-        .padding([.top, .bottom])
+        .padding(.vertical, 8)
     }
 
     func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -1,0 +1,26 @@
+//
+//  Topic002CardView.swift
+//  LayoutGame
+//
+//  Created by MiharuNaruse on 2022/07/23.
+//
+
+import SwiftUI
+
+struct Topic002CardView: View {
+    // MARK: Internal Stored Properties
+
+    var vital: Vital
+
+    // MARK: Body
+
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct Topic002CardView_Previews: PreviewProvider {
+    static var previews: some View {
+        Topic002CardView(vital: Vital.sampleData[0])
+    }
+}

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -13,7 +13,7 @@ struct Topic002CardView: View {
 
     var vital: Vital
 
-    var dateComponentsFormatter: DateComponentsFormatter {
+    private var dateComponentsFormatter: DateComponentsFormatter {
         let formatter = DateComponentsFormatter()
         formatter.unitsStyle = .full
         formatter.allowedUnits = [.day, .hour, .minute]
@@ -51,6 +51,7 @@ struct Topic002CardView: View {
 
     // MARK: Private Functions
 
+    private func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = style
         formatter.locale = .current

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -5,6 +5,7 @@
 //  Created by MiharuNaruse on 2022/07/23.
 //
 
+import Foundation
 import SwiftUI
 
 struct Topic002CardView: View {
@@ -15,12 +16,51 @@ struct Topic002CardView: View {
     // MARK: Body
 
     var body: some View {
-        Text("Hello, world!")
+        VStack(alignment: .leading) {
+            HStack {
+                Label(vital.title, systemImage: vital.iconSystemName)
+                    .foregroundColor(vital.color)
+                    .font(.headline)
+                Spacer()
+                // TODO: 相対日付の表示の仕方
+                Text(vital.date, style: .relative)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            switch vital.value {
+            case let .number(value: value, style: style, customUnit: customUnit):
+
+                let formatter = numberFormatter(style: style)
+                // TODO: フォントサイズ
+                Text("\(formatter.string(from: value as NSNumber) ?? "")\(customUnit ?? "")")
+                    .font(.title)
+
+            case let .dateComponents(dateComponents):
+                // TODO: DateComponents をフォーマットする。
+//                Text(dateComponents, style: .offset)
+                Text("Hello, world!")
+
+            case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
+                // TODO: フォントサイズ
+                Text("\(String(format: "%.1f", value))\(unit.symbol)")
+                    .font(.title)
+            }
+        }
+        .padding([.top, .bottom])
+    }
+
+    func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = style
+        formatter.locale = .current
+        return formatter
     }
 }
 
 struct Topic002CardView_Previews: PreviewProvider {
     static var previews: some View {
         Topic002CardView(vital: Vital.sampleData[0])
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -22,8 +22,7 @@ struct Topic002CardView: View {
                     .foregroundColor(vital.color)
                     .font(.headline)
                 Spacer()
-                // TODO: 相対日付の表示の仕方
-                Text(vital.date, style: .relative)
+                Text(RelativeDateTimeFormatter().localizedString(for: vital.date, relativeTo: Date.now))
                     .font(.subheadline)
                     .foregroundColor(.secondary)
             }

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -34,13 +34,13 @@ struct Topic002CardView: View {
 
     // MARK: Private Functions
 
-    /// 数値か否かによって、テキストを装飾する。
+    /// 目立つ装飾にすべきか否かを判別し、テキストを装飾する。
     /// - Parameter text: 装飾対象の文字列
     /// - Returns: 装飾されたテキスト
     private func modifiedText(_ text: String) -> Text {
         text
             .map {
-                if $0.isNumber || ["."].contains($0) {
+                if vital.value.shouldBeProminentDecoration($0) {
                     return Text(String($0))
                         .font(.system(.title, design: .rounded).weight(.medium))
                 } else {

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -36,31 +36,43 @@ struct Topic002CardView: View {
             Spacer(minLength: 16)
             switch vital.value {
             case let .number(value: value, style: style, customUnit: customUnit):
-
                 let formatter = numberFormatter(style: style)
-                // TODO: フォントサイズ
-                Text("\(formatter.string(from: value as NSNumber) ?? "")\(customUnit ?? "")")
-                    .font(.title)
+                modifiedText("\(formatter.string(from: value as NSNumber) ?? "")\(customUnit ?? "")")
 
             case let .dateComponents(dateComponents):
-                // TODO: フォントサイズ
-                Text(dateComponentsFormatter.string(from: dateComponents) ?? "")
-                    .font(.title)
+                modifiedText(dateComponentsFormatter.string(from: dateComponents) ?? "")
 
             case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
-                // TODO: フォントサイズ
-                Text("\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)")
-                    .font(.title)
+                modifiedText("\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)")
             }
         }
         .padding(.vertical, 8)
     }
 
-    func numberFormatter(style: NumberFormatter.Style) -> NumberFormatter {
+    // MARK: Private Functions
+
         let formatter = NumberFormatter()
         formatter.numberStyle = style
         formatter.locale = .current
         return formatter
+    }
+
+    /// 数値か否かによって、テキストを装飾する。
+    /// - Parameter text: 装飾対象の文字列
+    /// - Returns: 装飾されたテキスト
+    private func modifiedText(_ text: String) -> Text {
+        text
+            .map {
+                if $0.isNumber {
+                    return Text(String($0))
+                        .font(.system(.title, design: .rounded).weight(.medium))
+                } else {
+                    return Text(String($0))
+                        .font(.callout.weight(.medium))
+                        .foregroundColor(.secondary)
+                }
+            }
+            .reduce(Text("")) { $0 + $1 }
     }
 }
 

--- a/LayoutGame/Topic002/Topic002CardView.swift
+++ b/LayoutGame/Topic002/Topic002CardView.swift
@@ -49,8 +49,7 @@ struct Topic002CardView: View {
 
             case let .measurement(value: value, unit: unit, formattedUnit: formattedUnit):
                 // TODO: フォントサイズ
-                // TODO: `formattedUnit` 使うこと
-                Text("\(String(format: "%.1f", value))\(unit.symbol)")
+                Text("\(String(format: "%.1f", value))\(formattedUnit?.symbol ?? unit.symbol)")
                     .font(.title)
             }
         }

--- a/LayoutGame/Topic002/Topic002DetailView.swift
+++ b/LayoutGame/Topic002/Topic002DetailView.swift
@@ -1,0 +1,28 @@
+//
+//  Topic002DetailView.swift
+//  LayoutGame
+//
+//  Created by MiharuNaruse on 2022/07/23.
+//
+
+import SwiftUI
+
+struct Topic002DetailView: View {
+    // MARK: Internal Stored Properties
+
+    @Binding var vital: Vital
+
+    // MARK: Body
+
+    var body: some View {
+        Text("Hello, world!")
+    }
+}
+
+struct Topic002DetailView_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            Topic002DetailView(vital: .constant(Vital.sampleData[0]))
+        }
+    }
+}

--- a/LayoutGame/Topic002/Topic002View.swift
+++ b/LayoutGame/Topic002/Topic002View.swift
@@ -1,0 +1,35 @@
+//
+//  Topic002View.swift
+//  LayoutGame
+//
+//  Created by MiharuNaruse on 2022/07/23.
+//
+
+import SwiftUI
+
+struct Topic002View: View {
+    // MARK: Private Stored Properties
+
+    @State private var vitals: [Vital] = Vital.sampleData
+
+    // MARK: Body
+
+    var body: some View {
+        List {
+            ForEach($vitals) { $vital in
+                NavigationLink(destination: Topic002DetailView(vital: $vital)) {
+                    Topic002CardView(vital: vital)
+                }
+            }
+        }
+        .navigationTitle("バイタルデータ")
+    }
+}
+
+struct Topic002View_Previews: PreviewProvider {
+    static var previews: some View {
+        NavigationView {
+            Topic002View()
+        }
+    }
+}


### PR DESCRIPTION
## 変更の概要

- SwiftUI レイアウト一本勝負 002
    - https://twitter.com/treastrain/status/1549595274653609984?s=20&t=95_8D1A7S-b2pasDOdNOvA

## やったこと

- [x] ホーム画面のリストへ「002」へのリンクを追加しました。
- [x] 課題で指定された画面を `Topic002View` として作成しました。
- [x] 課題で指定された画面のカードビューを `Topic002CardView` として作成しました。
- [x] 課題では指定されませんでしたが、課題で指定された画面のリストをタップすると遷移する画面が存在すると想定し、 `vital` のデータを Binding で受け取る画面を `Topic002DetailView` として作成しました。
- [x] 課題でサンプルとして提示された `Vital` のデータモデルを改修して利用しました。具体的には、グローバル定数として定義されていた、サンプルデータを、 `Vital` のエクステンションとして定義し直しました。

## 変更内容

-  iPhone 13 mini

![Simulator Screen Shot - iPhone 13 mini - 2022-07-25 at 17 48 01](https://user-images.githubusercontent.com/35392604/180742409-e24d5e1b-732a-4040-8682-d62b59b40d63.png)

- Apple Watch Series 7 - 41mm 

![Simulator Screen Shot - Apple Watch Series 7 - 41mm - 2022-07-25 at 17 47 19](https://user-images.githubusercontent.com/35392604/180742451-bf36914f-59dc-4c7e-a97d-d144934be0b9.png) ![Simulator Screen Shot - Apple Watch Series 7 - 41mm - 2022-07-25 at 17 47 39](https://user-images.githubusercontent.com/35392604/180742460-8aefcdc2-9c98-4d52-92bc-03d37491bc9c.png)

## 影響範囲

- メンバーに影響すること
    - ホーム画面のリストへ「002」へのリンクを追加しました。

## どうやるのか

- 使い方
    - ホーム画面のリストの「002」をタップしてください。課題で指定された画面が開きます。

## 課題

- 悩んでいること
    - ディスクロージャーの位置が指定された画面通りではなく、上に移動させる方法がわかリませんでした。
    - 相対日付が「昨日」ではなく「1日前」と出てくる理由を未調査です。

## 備考

- その他に伝えたいこと
    - `Vital.Value` のデータを整理し、単位付きの文字列に変換した文字列を、将来他の画面でも利用可能なように、 `Vital`  内に定義しました。
    - また、その文字列のうち、目立つ装飾にすべき数値やカンマを判別するためのメソッドも `Vital` 内に定義しました。
    - それぞれ、個別の View から呼び出して利用してください。
